### PR TITLE
Incorporated some of Thelucyinside's changes + other cosmetic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ python transplant_embeddings.py /path/to/donor_model /path/to/target_model /path
 ```
 
 ### Options
+
 | Flag | Description |
 |------|-------------|
 | `--overwrite` | Replace existing output directory |
 | `--unmapped-init-scale [0-1]` | Initialize unmapped output tokens with scaled mean embeddings (only useful if you plan to fine-tune) |
 | `--use-cpu-only` | Use CPU instead of GPU with float32 precision |
+| `--trust-remote-code` | Allow custom code execution when loading models with non-standard architectures |
 | `--verbose` | Show detailed token mapping output |
 
 ### Example

--- a/transplant_vocab.py
+++ b/transplant_vocab.py
@@ -155,10 +155,11 @@ def main():
     # NOTE: The config file is often wrong, so get calculate from the tokenizer instead
     actual_target_vocab_size = max(target_tokenizer.vocab.values()) + 1
 
-    # Initialize new embeddings
+    # NOTE: We need to "untie" the lm_head weights for models with tie_word_embeddings = True
     donor_embed_tokens = model.model.embed_tokens.weight
     donor_lm_head = model.model.embed_tokens.weight if donor_config.get("tie_word_embeddings", False) else model.lm_head.weight
 
+    # Initialize new embeddings
     new_embed_tokens = torch.zeros(
         (target_vocab_size, donor_config["hidden_size"]),
         dtype = donor_embed_tokens.dtype,

--- a/transplant_vocab.py
+++ b/transplant_vocab.py
@@ -15,33 +15,36 @@ import sys
 from typing import Tuple, Dict
 
 import torch
-import torch.nn as nn
 from tqdm import tqdm
-from transformers import AutoTokenizer, AutoModelForCausalLM, PretrainedConfig
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+
+import torch.nn as nn
 
 def parse_arguments() -> argparse.Namespace:
     """Parse and validate command line arguments"""
     parser = argparse.ArgumentParser(
-        description="Transplant token embeddings between language models",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description = "Transplant token embeddings between language models",
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("donor_dir", help="Path to donor model directory")
-    parser.add_argument("target_dir", help="Path to target model directory")
-    parser.add_argument("output_dir", help="Path to output model directory")
-    parser.add_argument("--overwrite", action="store_true", 
-                       help="Overwrite output directory if it exists")
-    parser.add_argument("--unmapped-init-scale", type=float, default=0.0,
-                       help="Scale factor [0-1] for initializing unmapped lm_head tokens")
-    parser.add_argument("--use-cpu-only", action="store_true",
-                       help="Use CPU only for model loading and processing in float32")
-    parser.add_argument("--verbose", action="store_true",
-                       help="Show detailed token mapping output")
+    parser.add_argument("donor_dir", help = "Path to donor model directory")
+    parser.add_argument("target_dir", help = "Path to target model directory")
+    parser.add_argument("output_dir", help = "Path to output model directory")
+    parser.add_argument("--overwrite", action = "store_true",
+                       help = "Overwrite output directory if it exists")
+    parser.add_argument("--unmapped-init-scale", type = float, default = 0.0,
+                       help = "Scale factor [0-1] for initializing unmapped lm_head tokens")
+    parser.add_argument("--use-cpu-only", action = "store_true",
+                       help = "Use CPU only for model loading and processing in float32")
+    parser.add_argument("--trust-remote-code", action = "store_true",
+                       help = "Allow custom code execution when loading models with non-standard architectures")
+    parser.add_argument("--verbose", action = "store_true",
+                       help = "Show detailed token mapping output")
 
     args = parser.parse_args()
-    
+
     if not (0.0 <= args.unmapped_init_scale <= 1.0):
         sys.exit(f"Error: --unmapped-init-scale must be between 0.0 and 1.0 (got {args.unmapped_init_scale})")
-        
+
     return args
 
 def validate_directories(args: argparse.Namespace) -> None:
@@ -59,9 +62,9 @@ def validate_directories(args: argparse.Namespace) -> None:
             shutil.rmtree(args.output_dir)
         else:
             sys.exit(f"Error: Output directory exists (use --overwrite to replace): {args.output_dir}")
-    
+
     try:
-        os.makedirs(args.output_dir, exist_ok=True)
+        os.makedirs(args.output_dir, exist_ok = True)
     except OSError as e:
         sys.exit(f"Error: Failed to create output directory: {e}")
 
@@ -72,8 +75,8 @@ def load_model_config(path: str) -> dict:
         sys.exit(f"Error: Config file not found at {config_path}")
 
     try:
-        print(f"Loading config from '{path}'... ", end="")
-        with open(config_path, "r", encoding="utf-8") as f:
+        print(f"Loading config from '{path}'... ", end = "")
+        with open(config_path, "r", encoding = "utf-8") as f:
             config = json.load(f)
         print("Done.")
     except Exception as e:
@@ -81,129 +84,124 @@ def load_model_config(path: str) -> dict:
 
     return config
 
-def load_model(path: str, torch_dtype=None) -> AutoModelForCausalLM:
-    """Load model with error handling"""
-    try:
-        print(f"Loading model from '{path}'... ", end="")
-        if torch_dtype is not None:
-            model = AutoModelForCausalLM.from_pretrained(path, device_map="auto", torch_dtype=torch_dtype)
-        else:
-            model = AutoModelForCausalLM.from_pretrained(path, device_map="cpu")  # Will load (and save) as torch.float32
-        print("Done.")
-        return model
-    except Exception as e:
-        sys.exit(f"Failed to load model: {e}")
-
-def load_tokenizer(path: str) -> AutoTokenizer:
+def load_tokenizer(path: str, trust_remote_code = False) -> AutoTokenizer:
     """Load tokenizer with error handling"""
     try:
-        print(f"Loading tokenizer from '{path}'... ", end="")
-        tokenizer = AutoTokenizer.from_pretrained(path)
+        print(f"Loading tokenizer from '{path}'... ", end = "")
+        tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code = trust_remote_code)
         print("Done.")
         return tokenizer
     except Exception as e:
         sys.exit(f"Failed to load tokenizer: {e}")
 
+def load_model(path: str, trust_remote_code = False, torch_dtype = None) -> AutoModelForCausalLM:
+    """Load model with error handling"""
+    try:
+        print(f"Loading model from '{path}'... ", end = "")
+        if torch_dtype is not None:
+            model = AutoModelForCausalLM.from_pretrained(
+                path,
+                device_map = "auto",
+                trust_remote_code = trust_remote_code,
+                torch_dtype = torch_dtype
+            )
+        else:
+            model = AutoModelForCausalLM.from_pretrained(
+                path,
+                trust_remote_code = trust_remote_code,
+                device_map = "cpu"  # Will also load (and save) as torch.float32
+            )
+        print("Done.")
+        return model
+    except Exception as e:
+        sys.exit(f"Failed to load model: {e}")
+
 def main():
     args = parse_arguments()
     validate_directories(args)
-    
-    # Load tokenisers and configurations
+
+    # Load configurations
     donor_config = load_model_config(args.donor_dir)
-    donor_tokeniser = load_tokenizer(args.donor_dir)
     target_config = load_model_config(args.target_dir)
-    target_tokeniser = load_tokenizer(args.target_dir)
 
-    # Load the model
-    if args.use_cpu_only:
-        model = load_model(args.donor_dir)
+    # Retrieving the donor vocabulary size (for both flat and nested configurations)
+    if "text_config" in donor_config and "vocab_size" in donor_config["text_config"]:
+        donor_vocab_size = donor_config["text_config"]["vocab_size"]
     else:
-        model = load_model(args.donor_dir, torch_dtype=donor_config.get("torch_dtype", None))
+        assert "vocab_size" in donor_config, "vocab_size not found in source model config"
+        donor_vocab_size = donor_config["vocab_size"]
+    print(f"Donor vocab size: {donor_vocab_size}")
 
-    # Validate vocab_size and hidden_size exists
-    assert "vocab_size" in target_config, "vocab_size not found in target model config"
+    # Retrieving the target vocabulary size (for both flat and nested configurations)
+    if "text_config" in target_config and "vocab_size" in target_config["text_config"]:
+        target_vocab_size = target_config["text_config"]["vocab_size"]
+    else:
+        assert "vocab_size" in target_config, "vocab_size not found in target model config"
+        target_vocab_size = target_config["vocab_size"]
+    print(f"Target vocab size: {target_vocab_size}")
+
     assert "hidden_size" in donor_config, "hidden_size not found in donor model config"
 
-    # Get vocabulary sizes
-    target_vocab_size = target_config["vocab_size"]
-    actual_vocab_size = max(target_tokeniser.vocab.values()) + 1
+    # Load tokenizers
+    donor_tokenizer = load_tokenizer(args.donor_dir, args.trust_remote_code)
+    target_tokenizer = load_tokenizer(args.target_dir, args.trust_remote_code)
+
+    # Load the donor model
+    if args.use_cpu_only:
+        model = load_model(args.donor_dir, args.trust_remote_code)
+    else:
+        model = load_model(args.donor_dir, args.trust_remote_code, donor_config.get("torch_dtype", None))
+
+    # NOTE: The config file is often wrong, so get calculate from the tokenizer instead
+    actual_target_vocab_size = max(target_tokenizer.vocab.values()) + 1
 
     # Initialize new embeddings
     donor_embed_tokens = model.model.embed_tokens.weight
-    donor_lm_head = model.model.embed_tokens.weight if donor_config["tie_word_embeddings"] else model.lm_head.weight
-    
+    donor_lm_head = model.model.embed_tokens.weight if donor_config.get("tie_word_embeddings", False) else model.lm_head.weight
+
     new_embed_tokens = torch.zeros(
         (target_vocab_size, donor_config["hidden_size"]),
-        dtype=donor_embed_tokens.dtype,
-        device=donor_embed_tokens.device
+        dtype = donor_embed_tokens.dtype,
+        device = donor_embed_tokens.device
     )
     new_lm_head = torch.zeros(
         (target_vocab_size, donor_config["hidden_size"]),
-        dtype=donor_lm_head.dtype,
-        device=donor_lm_head.device
+        dtype = donor_lm_head.dtype,
+        device = donor_lm_head.device
     )
 
     # Track mapping statistics
-    one_to_one_count = 0
-    two_to_one_count = 0
-    three_plus_to_one_count = 0
-    
+    mapping_counts = {}
+
     # Track lm_head statistics
     lm_head_set_count = 0
     lm_head_scaled_count = 0
-    
+
     # Used to track already used prefix tokens for the lm_head
     used_prefix_tokens = set()
-    
+
     # Configure progress display
-    iterator = range(actual_vocab_size)
+    iterator = range(actual_target_vocab_size)
     if not args.verbose:
-        iterator = tqdm(iterator, desc="Transplanting tokens", unit="token")
-    
+        iterator = tqdm(iterator, desc = "Transplanting tokens", unit = "token")
+
     for idx in iterator:
-        decoded = target_tokeniser.decode([idx], decode_special_tokens=True)
-        encoded = donor_tokeniser.encode(decoded, add_special_tokens=False, return_tensors="pt").flatten()
+        decoded = target_tokenizer.decode([idx], decode_special_tokens = True)
+        encoded = donor_tokenizer.encode(decoded, add_special_tokens = False, return_tensors = "pt").flatten()
 
         if args.verbose:
             print(f"{idx:5d}: {repr(decoded)} → {encoded.tolist()}")
 
         # Track mapping types
-        if encoded.numel() == 1:
-            one_to_one_count += 1
-        elif encoded.numel() == 2:
-            two_to_one_count += 1
+        if encoded.numel() in mapping_counts:
+            mapping_counts[encoded.numel()] += 1
         else:
-            three_plus_to_one_count += 1
+            mapping_counts[encoded.numel()] = 1
 
         # Use only the final token of encoded sequence for input embeddings
-        # NOTE: The rationale for doing this rather than turboderp's original idea to
-        #       use the mean is because of the way the LLMs take the current token's
-        #       embedding, perform lots of vector additions, and generate the next
-        #       token - it's the transformer blocks that "look backward" so taking
-        #       the mean doesn't really make sense... If the model is fine-tuned
-        #       rather than used "as is"; then the different many-to-one embeddings
-        #       should update the transformer blocks to look at the tokens that make
-        #       up the start of the words (eg: "think-ing" and "drink-ing" will get
-        #       assigned the same word embedding from our "last token only" method).
         new_embed_tokens[idx] = donor_embed_tokens[encoded[-1]]
 
         # Use only the first token for head embeddings (unless asked to use scaled mean)
-        # NOTE: The rationale for doing this rather than turboderp's original idea to
-        #       use the mean is because again, using the mean pulls in word endings
-        #       that the model will only care about on the next token (eg: consider
-        #       the "think-ing" and "drink-ing" example - the model will decide on the
-        #       ending on the next auto-regressive pass; not on this pass).
-        #       - The reason we are careful not to assign the same token more than once,
-        #         is to not bias the probabilities using lots of different words using
-        #         the same prefix stem (eg: "th-ink", "th-inking", "th-ought", etc).
-        #       - The option of using a scaled down mean of the multi-token head
-        #         embeddings is purely for further fine-tuning, as it will likely be a
-        #         better initialisation than zeros to train from.
-        #       - Mathematically, scaling the logits (via embeddings dot-product) makes 
-        #         little sense, and to split tokens whilst keeping the rest of the
-        #         probabilities correct we should *SUBTRACT* log(n) from each in the
-        #         group of n-tokens we wish to split, but sadly there's no 'lm_head.bias'.
-        #         (see Softmax's relation to "Independence of Irrelevant Alternatives").
         prefix_token = encoded[0].item()
         if prefix_token not in used_prefix_tokens:
             used_prefix_tokens.add(prefix_token)
@@ -212,15 +210,15 @@ def main():
         elif args.unmapped_init_scale > 0:
             encode_tokens = encoded.flatten()
             head_embeddings = donor_lm_head[encode_tokens]
-            new_lm_head[idx] = head_embeddings.mean(dim=0) * args.unmapped_init_scale
+            new_lm_head[idx] = head_embeddings.mean(dim = 0) * args.unmapped_init_scale
             lm_head_scaled_count += 1
 
     # Print statistics
     print("\nTransplant mappings:")
-    print(f"- 1 to 1  : {one_to_one_count} ({one_to_one_count/actual_vocab_size:.1%})")
-    print(f"- 2 to 1  : {two_to_one_count} ({two_to_one_count/actual_vocab_size:.1%})")
-    print(f"- 3+ to 1 : {three_plus_to_one_count} ({three_plus_to_one_count/actual_vocab_size:.1%})")
-    
+    for count, occurrences in sorted(mapping_counts.items()):
+        mapping_label = f"{count} to 1"
+        print(f"- {mapping_label:<8}: {occurrences} ({occurrences/actual_target_vocab_size:.1%})")
+
     print("\nHead initialized with:")
     lm_head_zeroed_count = target_vocab_size - (lm_head_set_count + lm_head_scaled_count)
     print(f"- Copies : {lm_head_set_count} ({lm_head_set_count/target_vocab_size:.1%})")
@@ -233,33 +231,33 @@ def main():
     old_dtype = model.model.embed_tokens.weight.dtype
 
     # Update the state_dict with new embeddings
-    new_state_dict['model.embed_tokens.weight'] = new_embed_tokens.to(dtype=old_dtype)
-    new_state_dict['lm_head.weight'] = new_lm_head.to(dtype=old_dtype)
+    new_state_dict['model.embed_tokens.weight'] = new_embed_tokens.to(dtype = old_dtype)
+    new_state_dict['lm_head.weight'] = new_lm_head.to(dtype = old_dtype)
 
     # Update model architecture
     model.model.embed_tokens.num_embeddings = target_vocab_size
     model.lm_head.out_features = target_vocab_size
-    
+
     # Update model config
     model.config.update({
         'vocab_size': target_vocab_size,
-        'bos_token_id': target_tokeniser.bos_token_id,
-        'eos_token_id': target_tokeniser.eos_token_id,
+        'bos_token_id': target_tokenizer.bos_token_id,
+        'eos_token_id': target_tokenizer.eos_token_id,
     })
-    
-    # Add pad_token_id if it exists in the target tokeniser
-    if target_tokeniser.pad_token_id is not None:
-        model.config.update({'pad_token_id': target_tokeniser.pad_token_id})
-    
+
+    # Add pad_token_id if it exists in the target tokenizer
+    if target_tokenizer.pad_token_id is not None:
+        model.config.update({'pad_token_id': target_tokenizer.pad_token_id})
+
     # Set tie_word_embeddings to False if it exists
     if hasattr(model.config, 'tie_word_embeddings'):
         model.config.update({'tie_word_embeddings': False})
 
-    # Save final model and tokeniser
-    print(f"\nSaving model and tokeniser to {args.output_dir}")
-    model.save_pretrained(args.output_dir, state_dict=new_state_dict)
-    target_tokeniser.save_pretrained(args.output_dir)
-    
+    # Save final model and tokenizer
+    print(f"\nSaving model and tokenizer to {args.output_dir}")
+    model.save_pretrained(args.output_dir, state_dict = new_state_dict, safe_serialization = True)
+    target_tokenizer.save_pretrained(args.output_dir)
+
     print("Operation completed successfully")
 
 if __name__ == "__main__":


### PR DESCRIPTION
@Thelucyinside The only problem I noticed was:

```python
    # Determine actual vocab size, considering tokenizer special tokens
    actual_vocab_size = source_vocab_size # Changed to source_vocab_size
```

This should be kept as:

```python
    actual_vocab_size = max(target_tokenizer.vocab.values()) + 1
```

The reason for using this is that we want to iterate through all the tokens in the `tokenizer.json` file which often isn't the same as `target_vocab_size`.

From the few models I've tested this on; `target_vocab_size` seems to match the dimensions of `embed_tokens.weight` and `lm_head.weight` always though.