### PR TITLE
Removed `unmapped-init-scale` and replaced with `weighting-decay-factor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ We use **D** (**MOSTLY** the first token) because:
 - Using means or scaling logits isn't mathematically ideal for probability distribution.
 - Proper token splitting would require subtracting `log(n)` from each token in an n-token group.
 - In the absence of an `lm_head.bias`, our approach provides the most practical solution.
-- The `--weighting-decay-factor` parameter controls how we handle cases where one target token maps to multiple donor tokens. The default value of `0.5` balances between preserving the importance of the first token while still incorporating information from all tokens in the sequence. Values closer to `1.0` may provide better initialization for fine-tuning but could produce less reliable outputs if used without any further fine-tuning.
+- The `--weighting-decay-factor` parameter controls how we handle cases where one target token maps to multiple donor tokens. The default value of `0.5` balances between preserving the importance of the first token while still incorporating information from all tokens in the sequence. Values closer to `0.0` or `1.0` may provide better initialisations for fine-tuning but could produce less reliable outputs if used without any further fine-tuning.
 
 ## Credit
 


### PR DESCRIPTION
The logic behind this change is as follows:

- The old method of choosing the first token only for `lm_head` causes probability mass inflation due to many prefixes getting dotted to give the same logit values going into Softmax.
- The old method of taking the uniform arithmetic mean for `lm_head` inappropriately gives too much weight to trailing tokens.

The new method can still do both these cases by setting `--weighting-decay-factor` to the extremes of `0` or `1`, but by default uses `0.5` which uses a "front-loaded" exponentially-weighted mean of the geometric progression:

```
1, 0.5, 0.25, 0.125, ...
```

so "earlier" vectors have more influence, and the dot- products shouldn't all yield the same value for shared prefixes.